### PR TITLE
Fix output duplication in set-token command

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -28,7 +28,6 @@ export async function saveToken(token) {
     const configDir = await getConfigDir();
     const tokenFile = join(configDir, 'token');
     await writeFile(tokenFile, token);
-    console.log('Token saved successfully!');
   } catch (err) {
     throw new Error(`Error saving token: ${err.message}`);
   }


### PR DESCRIPTION
Related to #1

Remove the console log "Token saved successfully" from the `saveToken` function in `src/utils/config.js`.

* Ensure the `saveToken` function only saves the token without logging

