### PR TITLE
fix: resolve token loading issue for tunnel authentication

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -38,9 +38,15 @@ export async function loadToken() {
     const configDir = await getConfigDir();
     const tokenFile = join(configDir, 'token');
     const token = await readFile(tokenFile, 'utf8');
-    return token.trim();
+    const trimmedToken = token.trim();
+    if (!trimmedToken) {
+      throw new Error('Token file exists but is empty');
+    }
+    return trimmedToken;
   } catch (err) {
-    if (err.code === 'ENOENT') return '';
+    if (err.code === 'ENOENT') {
+      throw new Error('No token found. Use set-token command to save a token first');
+    }
     throw new Error(`Error loading token: ${err.message}`);
   }
 }


### PR DESCRIPTION
Fixes #3

The loadToken() function was returning empty string when no token file existed, causing the tunnel command to pass empty tokens to the server and fail authentication.

Fixed by:
- Throwing error when no token file exists instead of returning empty string
- Throwing error when token file exists but is empty
- Adding clear error messages for both scenarios

This ensures saved tokens are properly loaded and used for authentication.

Generated with [Claude Code](https://claude.ai/code)