### PR TITLE
chore: deprecate deploy command in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.3] - 2025-09-05
+
+### Deprecated
+- ⚠️ `deploy` command is now deprecated and hidden from CLI help while remaining functional
+
+---
+
 ## [1.4.2] - 2025-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,15 +4,12 @@ A Node.js client for the relay tunnel service, allowing you to expose local serv
 
 ## 🆕 What's New in v1.4.2
 
-- ✅ **New deployment types**: Added support for `node` and `nextjs` deployments
-- ✅ **Package.json validation**: Node.js and Next.js deployments now require a package.json file
-- ✅ **Deploy type restrictions**: Allowed types are now `web`, `react`, `static`, `node`, and `nextjs`
 - 📦 **Larger uploads**: Max archive size increased to 100MB
 - ✨ Terminal animations and server simplification from v1.4.0 retained
 
 ## Previous (v1.4.0)
 
-- ✨ **Terminal animations**: Clear visual feedback with animated steps for connecting, establishing tunnels, uploads, and deployment status (uses `chalk`)
+- ✨ **Terminal animations**: Clear visual feedback with animated steps for connecting, establishing tunnels, uploads, and status monitoring (uses `chalk`)
 - 🌐 **Server address simplified**: Always uses `tcp.relais.dev:1080` (failover and old IP/ports removed)
 - 📝 **Docs & CLI**: Updated defaults and messages to reflect the new server and animations
 
@@ -77,34 +74,18 @@ npm run build:win-only
 ```bash
 # Windows
 dist/relais-win.exe tunnel -p 3000
-dist/relais-win.exe deploy ./my-app
 
-# Linux/macOS  
+# Linux/macOS
 ./dist/relais-linux tunnel -p 3000
-./dist/relais-macos deploy ./my-app
 ```
 
 **Benefits:**
 - ✅ No Node.js installation required
-- ✅ Single file deployment (~37MB)
+- ✅ Single file distribution (~37MB)
 - ✅ Same functionality as Node.js version
-- ✅ Perfect for CI/CD and server deployments
+- ✅ Perfect for CI/CD and server usage
 
 ## Usage
-
-### Deploy a project
-
-```bash
-relais deploy [folder] [-t web|react|static|node|nextjs] [-d domain] [-f config.json] [-v]
-```
-
-Options:
-- `-t, --type <type>` : Deployment type (allowed: web, react, static, node, nextjs; default: web)
-- `-d, --domain <domain>` : Custom domain
-- `-f, --file <path>` : Path to deploy config JSON (default: `relais.json`)
-- `-v, --verbose` : Detailed logging
-
-Note: Node.js and Next.js deployments require a `package.json` file in the project folder.
 
 ### Save a token
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relais",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Node.js client for the relay tunnel service - Agent mode with persistent reconnection for network resilience",
   "main": "src/cli.cjs",
   "type": "module",

--- a/src/cli-standalone.cjs
+++ b/src/cli-standalone.cjs
@@ -75,7 +75,7 @@ program
   });
 
 program
-  .command('deploy [folder]')
+  .command('deploy [folder]', { hidden: true })
   .description('🚀 Deploy a project folder to Relais platform (experimental)')
   .option('-t, --type <type>', 'Deployment type (web, react, static, node, nextjs)', 'web')
   .option('-d, --domain <domain>', 'Custom domain for deployment')

--- a/src/cli.cjs
+++ b/src/cli.cjs
@@ -42,7 +42,7 @@ program
   });
 
 program
-  .command('deploy [folder]')
+  .command('deploy [folder]', { hidden: true })
   .description('🚀 Deploy a project folder to Relais platform (experimental)')
   .option('-t, --type <type>', 'Deployment type (web, react, static, node, nest)', 'web')
   .option('-d, --domain <domain>', 'Custom domain for deployment')

--- a/src/cli.cjs
+++ b/src/cli.cjs
@@ -25,7 +25,7 @@ const program = new Command();
 program
   .name('relais')
   .description('Node.js client for the relay tunnel service')
-  .version('1.5.0');
+  .version('1.5.1');
 
 program
   .command('set-token <token>')


### PR DESCRIPTION
## Summary
- hide the deploy command from CLI help while keeping it functional
- remove deploy usage references from the README
- document the deploy command deprecation in the changelog

## Testing
- not run (missing local dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e40752cacc8333ae26db0fa29909ea